### PR TITLE
feat(workflow): self-improvement loop, verification gate, stop-and-replan

### DIFF
--- a/agents/developer.md
+++ b/agents/developer.md
@@ -36,7 +36,8 @@ When invoked:
 3. **Scaffold**: Set up files, routes, components following project conventions
 4. **Implement**: Build feature incrementally; use design system components when available
 5. **Test**: Write tests alongside implementation; verify acceptance criteria
-6. **PR**: Create pull request with clear description, screenshots, and test evidence
+6. **Verify**: Before opening the PR, self-check: all tests pass, no linting or type errors, acceptance criteria fully met, design matches mockup. Ask: "Would a staff engineer approve this?"
+7. **PR**: Create pull request with clear description, screenshots, and test evidence
 
 ## Tech Stack Awareness
 
@@ -74,3 +75,4 @@ When invoked:
 - If design is ambiguous, check with product-designer before improvising
 - If architecture question arises, escalate to tech-lead
 - If a ticket is too large, propose splitting it before starting
+- If something unexpected blocks progress mid-implementation (API mismatch, design assumption wrong, scope larger than planned): STOP, document the blocker as a comment on the issue, and coordinate with tech-lead or product-manager before continuing — don't push through

--- a/agents/qa-lead.md
+++ b/agents/qa-lead.md
@@ -23,6 +23,7 @@ When invoked:
 - Ask for release scope, risk areas, and quality standards if not provided
 - Always include happy path + edge cases + error states in test thinking
 - Define clear release gates with go/no-go criteria
+- When recurring defect patterns emerge or a significant issue was missed earlier in the process: document the pattern in `docs/lessons.md` with a prevention rule for future phases
 
 ## QA Checklist
 

--- a/agents/tech-lead.md
+++ b/agents/tech-lead.md
@@ -26,6 +26,7 @@ When invoked:
 - Propose multiple architecture/implementation options with trade-offs
 - Identify risks (security, performance, scalability) and mitigations
 - Advocate for quality, maintainability, and observability
+- If architecture assumptions prove incorrect during implementation: STOP, update the relevant ADR, assess the blast radius, and re-plan with the team before work continues
 
 ## Engineering Checklist
 

--- a/commands/kickoff.md
+++ b/commands/kickoff.md
@@ -20,6 +20,7 @@ Sobald ich geantwortet habe, starte den Workflow:
 - Erstelle ein GitHub Repo mit sinnvoller Struktur
 - Richte ein GitHub Projects Board ein (Backlog → Ready → In Progress → Review → Done)
 - Definiere Milestones: Discovery → Design → Architecture → Implementation → QA → Launch
+- Erstelle `docs/lessons.md` für phasenübergreifende Lernmuster (wird nach Phasenproblemen befüllt)
 
 ### Phase 2: Requirements (product-manager + ux-researcher)
 - Erarbeite im Dialog mit mir die Kernfeatures
@@ -65,5 +66,8 @@ Regeln:
 - Halte den Status im Repo aktuell (STATUS.md)
 - Wenn etwas unklar ist, frag nach — rate nicht
 - Zeig mir Zwischenergebnisse, damit ich früh korrigieren kann
+- Lies `docs/lessons.md` zu Beginn jeder Phase auf Muster, die relevant sein könnten
+- Wenn eine Phase Korrekturen brauchte oder etwas schiefgelaufen ist: halte die Lektion in `docs/lessons.md` fest — welches Muster war es und welche Regel hätte den Fehler verhindert?
+- Wenn etwas schiefläuft: STOPP und neu planen — nicht weiterpushen
 
 Starte jetzt mit deinen Rückfragen.


### PR DESCRIPTION
## Summary

Adapts three patterns from Claude Code best practices into our multi-agent product workflow:

- **Self-Improvement Loop**: `docs/lessons.md` is created in Phase 1 setup. Agents read it at each phase start and write to it after corrections or rework — so patterns don't repeat across phases.
- **Verification Before Done**: Developer agent now has an explicit Verify step (step 6) before opening a PR: run through the full checklist and ask "Would a staff engineer approve this?"
- **Stop and Re-Plan**: All three execution agents (developer, tech-lead, kickoff orchestrator) now have explicit rules to STOP and re-plan when something unexpected comes up — instead of pushing through.

## Files changed

- `commands/kickoff.md` — docs/lessons.md in Phase 1 + three new rules
- `agents/developer.md` — Verify step before PR + stop-and-replan in Collaboration
- `agents/tech-lead.md` — stop-and-replan when architecture assumptions prove wrong
- `agents/qa-lead.md` — document recurring defect patterns in docs/lessons.md

## What was NOT changed

Deliberately excluded "Autonomous Bug Fixing / Zero context switching" — this contradicts our "Human at every gate" principle, which is a core design decision of this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)