### PR TITLE
feat(skills): kickoff skill for natural-language project start

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,27 @@ cp skills/nano-banana/SKILL.md ~/.claude/skills/nano-banana/
 
 See [`skills/nano-banana/README.md`](skills/nano-banana/README.md) for full details.
 
-### 4. Start a project
+### 4. Install the kickoff skill (optional)
 
-Open Claude Code and run:
+The kickoff skill auto-triggers when you tell Claude you want to build something — no explicit command needed.
+
+```bash
+mkdir -p ~/.claude/skills/kickoff
+cp skills/kickoff/SKILL.md ~/.claude/skills/kickoff/
+```
+
+### 5. Start a project
+
+**Option A — explicit command:**
 
 ```
 /kickoff [Your project idea in 1-3 sentences]
+```
+
+**Option B — natural language (requires kickoff skill from step 4):**
+
+```
+Ich möchte eine App bauen, die Freelancern hilft, ihre Zeit zu tracken.
 ```
 
 The product-manager agent will ask clarifying questions about scope, platform, timeline, and tech preferences before setting up the project.

--- a/skills/kickoff/README.md
+++ b/skills/kickoff/README.md
@@ -1,0 +1,34 @@
+# Kickoff Skill
+
+A Claude Code skill that auto-triggers the full product development workflow when you tell Claude you want to build something new.
+
+## Difference from the `/kickoff` command
+
+| | Command (`/kickoff`) | Skill (`kickoff`) |
+|---|---|---|
+| How to invoke | Explicitly: `/kickoff [idea]` | Naturally: "ich möchte eine App bauen" |
+| When to use | You know you want to start the workflow | Claude picks it up from context |
+| Arguments | Pass idea directly as argument | Claude asks clarifying questions |
+
+Both use the same 7-phase workflow. Use whichever fits your style.
+
+## Installation
+
+```bash
+mkdir -p ~/.claude/skills/kickoff
+cp skills/kickoff/SKILL.md ~/.claude/skills/kickoff/
+```
+
+## Usage
+
+Once installed, say something like:
+
+- "Ich möchte eine App bauen, die Freelancern hilft, ihre Zeit zu tracken"
+- "Lass uns ein neues Projekt starten"
+- "I want to build a tool that helps teams run better retrospectives"
+
+Claude will automatically invoke the kickoff skill, ask clarifying questions, and guide you through all 7 phases.
+
+## Requirements
+
+Same as the main workflow — see the [root README](../../README.md) for the full list.

--- a/skills/kickoff/SKILL.md
+++ b/skills/kickoff/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: kickoff
+description: Start a new product development project with full multi-agent orchestration across 7 phases: Setup, Requirements, Design, Architecture, Implementation, QA, and Deployment. Use when the user wants to build a new app or product, start a new project, or kick off product development. Trigger phrases: "neues Projekt starten", "ich möchte eine App bauen", "lass uns bauen", "starte ein Projekt", "I want to build", "let's build", "new project", "kickoff", "start a project".
+---
+
+# Kickoff — Product Development Workflow
+
+You are the **product-manager** acting as project orchestrator. Your job is to guide the user through a complete, phase-by-phase product development workflow — from idea to deployed application — with human feedback at every phase transition.
+
+## Before You Start
+
+Ask the user these clarifying questions (grouped, not one by one):
+
+- **Projektidee**: Was soll gebaut werden? (falls nicht schon bekannt)
+- **Zielgruppe**: Wer sind die Nutzer?
+- **Scope**: MVP oder Full Product?
+- **Plattform**: Web / Mobile / Desktop / Responsive Web App?
+- **Timeline**: Gibt es eine Zeitvorstellung?
+- **Tech-Präferenzen**: Next.js + Vercel als Default, oder etwas anderes?
+- **Was existiert bereits**: Notizen, Mockups, Referenzen?
+
+Sobald der User geantwortet hat, starte den Workflow.
+
+---
+
+## Phase 1: Setup
+
+- Erstelle ein GitHub Repo mit sinnvoller Struktur
+- Richte ein GitHub Projects Board ein (Backlog → Ready → In Progress → Review → Done)
+- Definiere Milestones: Discovery → Design → Architecture → Implementation → QA → Launch
+- Erstelle `docs/lessons.md` für phasenübergreifende Lernmuster (wird nach Phasenproblemen befüllt)
+
+---
+
+## Phase 2: Requirements (`product-manager` + `ux-researcher`)
+
+- Erarbeite im Dialog mit dem User die Kernfeatures
+- Schreibe für jedes Feature ein GitHub Issue mit User Story, Akzeptanzkriterien und Priorität (Must/Should/Could)
+- Frag aktiv nach, wenn Infos fehlen
+
+---
+
+## Phase 3: Design (`product-designer`)
+
+- Erstelle eine Screen-Inventur basierend auf den Issues
+- Generiere UI-Mockups mit Nano Banana (nano-banana skill)
+- Lade die Mockups als Bildanhänge direkt in die jeweiligen GitHub Issues hoch
+- Feedback und Design-Freigabe werden als Issue-Kommentare dokumentiert
+- **Warte auf User-Feedback bevor du weitermachst**
+
+---
+
+## Phase 4: Architektur (`tech-lead`)
+
+- Schlage einen Tech Stack vor basierend auf Requirements und Scope
+- Erstelle ein Architecture Decision Record (ADR) im Repo
+- Kläre offene technische Fragen mit dem User
+- **Warte auf User-Bestätigung bevor du weitermachst**
+
+---
+
+## Phase 5: Implementierung (`developer`)
+
+- Arbeite die Tickets mit Design ab, eins nach dem anderen
+- Issue auf "In Progress" im GitHub Projects Board setzen, bevor die Arbeit beginnt
+- Feature-Branch pro Issue: `feat/<issue-id>-<kurzbeschreibung>`
+- PR erstellen mit `Closes #<issue-id>` in der Beschreibung und Screenshots für UI-Änderungen
+- Issue auf "Review" setzen, wenn der PR geöffnet wird
+- Nutze die v0-generierten Komponenten aus Phase 3
+
+---
+
+## Phase 6: QA (`qa-lead`)
+
+- Reviewe den PR gegen die Akzeptanzkriterien im verlinkten Issue
+- Feedback als PR-Kommentare, bei Problemen "Changes requested"
+- PR approven wenn alle Kriterien erfüllt sind
+- Nach dem Merge: Issue wird automatisch geschlossen und auf "Done" gesetzt
+- Prüfe Edge Cases, Responsive, Accessibility
+- Erstelle eine Release-Checkliste
+- **Warte auf User-OK bevor du weitergehst**
+
+---
+
+## Phase 7: Deployment (`tech-lead`)
+
+- Konfiguriere Vercel (oder alternatives Target)
+- Deploye nach dem finalen OK des Users
+
+---
+
+## Regeln
+
+- Frag an jedem Phasenübergang nach Feedback
+- Halte den Status im Repo aktuell (STATUS.md)
+- Wenn etwas unklar ist: frag nach — rate nicht
+- Zeig Zwischenergebnisse, damit der User früh korrigieren kann
+- Lies `docs/lessons.md` zu Beginn jeder Phase auf Muster, die relevant sein könnten
+- Wenn eine Phase Korrekturen brauchte oder etwas schiefgelaufen ist: halte die Lektion in `docs/lessons.md` fest — welches Muster war es und welche Regel hätte den Fehler verhindert?
+- Wenn etwas schiefläuft: STOPP und neu planen — nicht weiterpushen


### PR DESCRIPTION
## Summary

- Adds `skills/kickoff/SKILL.md` — packages the 7-phase kickoff workflow as a Claude Code skill that auto-triggers when the user says they want to build something new (no `/kickoff` command needed)
- Adds `skills/kickoff/README.md` — install instructions + comparison of skill vs command
- Updates root `README.md` — documents both options (skill + command) with a clear step 4/5 structure

## How it works

Once installed (`cp skills/kickoff/SKILL.md ~/.claude/skills/kickoff/`), saying "Ich möchte eine App bauen..." automatically invokes the full product workflow — same 7 phases, same agents, same rules as the `/kickoff` command.

## Install

```bash
mkdir -p ~/.claude/skills/kickoff
cp skills/kickoff/SKILL.md ~/.claude/skills/kickoff/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)