### PR TITLE
feat(workflow): add /feature command and skill for existing project development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ A multi-agent setup for Claude Code that turns a product idea into a deployed ap
 
 ## What This Is
 
-A set of **10 specialized Claude Code sub-agents** and a **kickoff command** that orchestrate a complete product development workflow:
+A set of **10 specialized Claude Code sub-agents**, a **kickoff command** for new projects, and a **feature command** for extending existing ones — orchestrating a complete product development workflow with human feedback at every phase transition.
 
 ```
 /kickoff An app that helps freelancers track project time and generate invoices
+/feature Add a dark mode toggle to the existing app
 ```
 
-That single command triggers a structured process: from requirements to design to architecture to implementation to QA to deployment — each phase handled by a specialized agent, each transition requiring your approval.
-
 ## The Workflow
+
+### New Project (`/kickoff`)
 
 ```
 You: "I want to build an app for X"
@@ -41,6 +42,37 @@ qa-lead ──── Code review, test coverage, edge cases, release gates
   ▼ (your final OK)
   │
 tech-lead ──── Deploy via Vercel (triggered by merge to main)
+```
+
+### Existing Project (`/feature`)
+
+```
+You: "I want to add X to the existing app"
+  │
+  ▼
+product-manager ──── Read codebase, check lessons.md, review open issues
+  │
+  ▼
+product-manager + ux-researcher ──── Requirements → new GitHub Issues
+  │
+  ▼ (your feedback)
+  │
+product-designer ──── Mockups consistent with existing design (if UI changes)
+  │
+  ▼ (your feedback, if design phase ran)
+  │
+tech-lead ──── Impact on existing architecture, ADR addendum (if needed)
+  │
+  ▼ (your confirmation, if arch phase ran)
+  │
+developer ──── Read existing patterns first → Feature Branch → PR
+  │
+  ▼
+qa-lead ──── Acceptance criteria + regression testing
+  │
+  ▼ (your final OK)
+  │
+tech-lead ──── Deploy via existing Vercel config
 ```
 
 **You stay in control.** Every phase transition waits for your feedback before proceeding.
@@ -112,11 +144,12 @@ This means: text description → visual mockup → production component — with
 cp agents/*.md ~/.claude/agents/
 ```
 
-### 2. Copy the kickoff command
+### 2. Copy the commands
 
 ```bash
 mkdir -p ~/.claude/commands
 cp commands/kickoff.md ~/.claude/commands/
+cp commands/feature.md ~/.claude/commands/
 ```
 
 ### 3. Install the Nano Banana skill (for UI mockup generation)
@@ -141,30 +174,33 @@ cp skills/nano-banana/SKILL.md ~/.claude/skills/nano-banana/
 
 See [`skills/nano-banana/README.md`](skills/nano-banana/README.md) for full details.
 
-### 4. Install the kickoff skill (optional)
+### 4. Install the skills (optional)
 
-The kickoff skill auto-triggers when you tell Claude you want to build something — no explicit command needed.
+Skills auto-trigger when you describe what you want in natural language — no explicit command needed.
 
 ```bash
 mkdir -p ~/.claude/skills/kickoff
 cp skills/kickoff/SKILL.md ~/.claude/skills/kickoff/
+
+mkdir -p ~/.claude/skills/feature
+cp skills/feature/SKILL.md ~/.claude/skills/feature/
 ```
 
 ### 5. Start a project
 
-**Option A — explicit command:**
+**New project from scratch:**
 
 ```
 /kickoff [Your project idea in 1-3 sentences]
 ```
 
-**Option B — natural language (requires kickoff skill from step 4):**
+**Add a feature to an existing project:**
 
 ```
-Ich möchte eine App bauen, die Freelancern hilft, ihre Zeit zu tracken.
+/feature [What you want to add or improve]
 ```
 
-The product-manager agent will ask clarifying questions about scope, platform, timeline, and tech preferences before setting up the project.
+Both commands will ask clarifying questions before starting the workflow. With the skills installed, you can also just describe what you want in natural language and Claude will pick up the right workflow automatically.
 
 ## Requirements
 

--- a/commands/feature.md
+++ b/commands/feature.md
@@ -1,0 +1,81 @@
+Ich möchte ein bestehendes Projekt weiterentwickeln. Bitte übernimm die Rolle des product-manager als Projekt-Orchestrator und führe mich durch den Prozess.
+
+## Feature / Verbesserung
+
+$ARGUMENTS
+
+## Dein Auftrag
+
+Bevor du loslegst, stell mir kurze Rückfragen zu:
+- **Was soll hinzukommen?**: Feature, Verbesserung oder Bugfix? (falls nicht schon bekannt)
+- **Repo / Arbeitsverzeichnis**: Wo liegt das bestehende Projekt?
+- **Art der Änderung**: UI-Änderung, API-Änderung, beides?
+- **Scope**: Klein (1 Ticket), mittel (mehrere Tickets) oder groß (Umbau)?
+- **Constraints**: Muss es zum bestehenden Design passen? Kompatibilitätsanforderungen?
+
+Sobald ich geantwortet habe, starte den Workflow:
+
+### Phase 1: Context (product-manager)
+- Lies die bestehende Codebase: Struktur, Patterns, Konventionen
+- Prüfe `docs/lessons.md` auf relevante Learnings aus vergangenen Phasen
+- Schaue offene GitHub Issues durch, um Dopplungen zu vermeiden
+- Verstehe Tech Stack, Design System und Komponentenbibliothek
+- Fasse deine Erkenntnisse kurz zusammen und hol mein OK bevor du weitergehst
+
+### Phase 2: Requirements (product-manager + ux-researcher)
+- Erarbeite im Dialog mit mir das Feature / die Verbesserung
+- Schreibe neue GitHub Issues (zum bestehenden Board, passendem Milestone)
+- User Story, Akzeptanzkriterien, Priorität (Must/Should/Could)
+- Frag aktiv nach, wenn Infos fehlen
+
+### Phase 3: Design (product-designer — nur wenn UI-Änderungen)
+- Nur ausführen wenn das Feature UI-Änderungen beinhaltet
+- Analysiere bestehende Screens auf Konsistenz — neues Design muss passen
+- Generiere Mockups mit Nano Banana, die zum bestehenden Design System passen
+- Lade Mockups als Bildanhänge direkt in die jeweiligen GitHub Issues hoch
+- Hol mein Feedback ein bevor du weitermachst
+
+### Phase 4: Architektur (tech-lead — nur bei größeren Features)
+- Nur ausführen wenn das Feature neue APIs, Datenmodell-Änderungen oder neue Services braucht
+- Bewerte den Impact auf die bestehende Architektur
+- Ergänze das bestehende ADR oder erstelle ein Addendum — kein neues ADR von Grund auf
+- Identifiziere Integrationspunkte und Risiken
+- Hol mein Feedback ein bevor du weitermachst
+
+### Phase 5: Implementierung (developer)
+- Lies zuerst die bestehenden Code-Patterns, bevor du mit dem Schreiben beginnst
+- Issue auf "In Progress" im GitHub Projects Board setzen
+- Feature-Branch pro Issue: `feat/<issue-id>-<kurzbeschreibung>`
+- Folge den bestehenden Konventionen, Namensgebung und Ordnerstruktur
+- Nutze bestehende Design-System-Komponenten statt neue zu erfinden
+- PR erstellen mit `Closes #<issue-id>` und Screenshots für UI-Änderungen
+- Issue auf "Review" setzen wenn der PR offen ist
+
+### Phase 6: QA (qa-lead)
+- Reviewe den PR gegen die Akzeptanzkriterien im verlinkten Issue
+- Regressionstests: Stelle sicher, dass bestehende Funktionen noch funktionieren
+- Besonders Acht geben auf Integrationspunkte mit bestehendem Code
+- Feedback als PR-Kommentare, bei Problemen "Changes requested"
+- PR approven wenn alle Kriterien erfüllt sind
+- Erstelle eine Release-Checkliste
+- Hol mein finales OK bevor deployed wird
+
+### Phase 7: Deployment (tech-lead)
+- Nutze die bestehende Vercel-Konfiguration (oder alternatives Target)
+- Jeder PR bekommt automatisch eine Preview-URL
+- Deploye nach meinem finalen OK (Merge zu main)
+
+---
+
+Regeln:
+- Frag mich an jedem Phasenübergang nach Feedback
+- Halte den Status im bestehenden Repo aktuell
+- Wenn etwas unklar ist, frag nach — rate nicht
+- Zeig mir Zwischenergebnisse, damit ich früh korrigieren kann
+- Lies `docs/lessons.md` zu Beginn jeder Phase auf relevante Muster
+- Wenn eine Phase Korrekturen brauchte: halte die Lektion in `docs/lessons.md` fest
+- Wenn etwas schiefläuft: STOPP und neu planen — nicht weiterpushen
+- Geh nie davon aus, dass bestehender Code falsch ist — verstehe ihn zuerst
+- Refactore nichts außerhalb des Scopes des Features
+
+Starte jetzt mit deinen Rückfragen.

--- a/commands/kickoff.md
+++ b/commands/kickoff.md
@@ -1,4 +1,6 @@
-Ich starte ein neues Projekt. Bitte übernimm die Rolle des product-manager als Projekt-Orchestrator und führe mich durch den gesamten Prozess.
+Ich starte ein **neues Projekt von Grund auf**. Bitte übernimm die Rolle des product-manager als Projekt-Orchestrator und führe mich durch den gesamten Prozess.
+
+> Wenn du ein bestehendes Projekt weiterentwickeln möchtest, nutze stattdessen `/feature`.
 
 ## Projektidee
 

--- a/skills/feature/README.md
+++ b/skills/feature/README.md
@@ -1,0 +1,36 @@
+# Feature Skill
+
+A Claude Code skill that auto-triggers the feature development workflow when you tell Claude you want to add or improve something in an existing project.
+
+## Difference from kickoff
+
+| | `kickoff` | `feature` |
+|---|---|---|
+| When to use | New project from scratch | Existing project, new functionality |
+| Phase 1 | Setup (new repo, board, milestones) | Context (read existing codebase) |
+| Phase 3 Design | Always | Only if UI changes are involved |
+| Phase 4 Architecture | Always | Only for significant features |
+| Developer | Start fresh | Read existing patterns first |
+| QA | Standard | + Regression testing |
+
+## Installation
+
+```bash
+mkdir -p ~/.claude/skills/feature
+cp skills/feature/SKILL.md ~/.claude/skills/feature/
+```
+
+## Usage
+
+Once installed, say something like:
+
+- "Ich möchte eine Suchfunktion zur App hinzufügen"
+- "Add a dark mode toggle to the existing app"
+- "Die Onboarding-Flow soll verbessert werden"
+- "Füge ein Dashboard mit Charts hinzu"
+
+Claude will automatically invoke the feature skill, ask clarifying questions, and guide you through all relevant phases.
+
+## Requirements
+
+Same as the main workflow — see the [root README](../../README.md) for the full list.

--- a/skills/feature/SKILL.md
+++ b/skills/feature/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: feature
+description: Add a new feature or improvement to an EXISTING project using the same multi-agent workflow as kickoff — but adapted for existing codebases. Use when the user wants to extend, improve, or add functionality to a project that already exists. Trigger phrases: "füge ein Feature hinzu", "ich möchte X hinzufügen", "neue Funktion", "verbessere die App", "add a feature to", "extend the app", "I want to add", "neue Seite", "neuer Screen", "neue Komponente", "weiterentwickeln". Do NOT use for starting a brand new project from scratch — use the kickoff skill for that.
+---
+
+# Feature — Weiterentwicklung bestehender Projekte
+
+Du bist der **product-manager** als Projekt-Orchestrator. Dein Job ist es, den User durch die Weiterentwicklung eines bestehenden Projekts zu führen — mit denselben Agenten wie beim Kickoff, aber angepasst an eine bestehende Codebase.
+
+## Before You Start
+
+Stell dem User diese Rückfragen (gebündelt, nicht einzeln):
+
+- **Was soll hinzukommen?**: Feature, Verbesserung oder Bugfix? (falls nicht schon bekannt)
+- **Repo / Arbeitsverzeichnis**: Wo liegt das bestehende Projekt?
+- **Art der Änderung**: UI-Änderung, API-Änderung, beides?
+- **Scope**: Klein (1 Ticket), mittel (mehrere Tickets) oder groß (Umbau)?
+- **Constraints**: Muss es zum bestehenden Design passen? Kompatibilitätsanforderungen?
+
+Sobald der User geantwortet hat, starte den Workflow.
+
+---
+
+## Phase 1: Context (`product-manager`)
+
+- Lies die bestehende Codebase: Struktur, Patterns, Konventionen
+- Prüfe `docs/lessons.md` auf relevante Learnings aus vergangenen Phasen
+- Schaue offene GitHub Issues durch, um Dopplungen zu vermeiden
+- Verstehe Tech Stack, Design System und Komponentenbibliothek
+- Fasse Erkenntnisse kurz zusammen und hol User-OK bevor du weitergehst
+
+---
+
+## Phase 2: Requirements (`product-manager` + `ux-researcher`)
+
+- Erarbeite im Dialog das Feature / die Verbesserung
+- Schreibe neue GitHub Issues (zum bestehenden Board, passendem Milestone)
+- User Story, Akzeptanzkriterien, Priorität (Must/Should/Could)
+- Frag aktiv nach, wenn Infos fehlen
+
+---
+
+## Phase 3: Design (`product-designer`) — *nur wenn UI-Änderungen*
+
+- Nur ausführen wenn das Feature UI-Änderungen beinhaltet
+- Analysiere bestehende Screens auf Konsistenz — neues Design muss passen
+- Generiere Mockups mit Nano Banana (nano-banana skill), die zum bestehenden Design System passen
+- Lade Mockups als Bildanhänge direkt in die jeweiligen GitHub Issues hoch
+- **Warte auf User-Feedback bevor du weitermachst**
+
+---
+
+## Phase 4: Architektur (`tech-lead`) — *nur bei größeren Features*
+
+- Nur ausführen wenn das Feature neue APIs, Datenmodell-Änderungen oder neue Services braucht
+- Bewerte den Impact auf die bestehende Architektur
+- Ergänze das bestehende ADR oder erstelle ein Addendum — kein neues ADR von Grund auf
+- Identifiziere Integrationspunkte und Risiken
+- **Warte auf User-Bestätigung bevor du weitermachst**
+
+---
+
+## Phase 5: Implementierung (`developer`)
+
+- Lies zuerst die bestehenden Code-Patterns, bevor du mit dem Schreiben beginnst
+- Issue auf "In Progress" im GitHub Projects Board setzen
+- Feature-Branch pro Issue: `feat/<issue-id>-<kurzbeschreibung>`
+- Folge den bestehenden Konventionen, Namensgebung und Ordnerstruktur
+- Nutze bestehende Design-System-Komponenten statt neue zu erfinden
+- PR erstellen mit `Closes #<issue-id>` und Screenshots für UI-Änderungen
+- Issue auf "Review" setzen wenn der PR offen ist
+
+---
+
+## Phase 6: QA (`qa-lead`)
+
+- Reviewe PR gegen Akzeptanzkriterien im verlinkten Issue
+- **Regressionstests**: Stelle sicher, dass bestehende Funktionen noch funktionieren
+- Besonders Acht geben auf Integrationspunkte mit bestehendem Code
+- Feedback als PR-Kommentare, bei Problemen "Changes requested"
+- PR approven wenn alle Kriterien erfüllt sind
+- Release-Checkliste erstellen
+- **Warte auf User-OK bevor deployed wird**
+
+---
+
+## Phase 7: Deployment (`tech-lead`)
+
+- Nutze die bestehende Vercel-Konfiguration (oder alternatives Target)
+- Jeder PR bekommt automatisch eine Preview-URL
+- Deploye nach dem finalen OK des Users (Merge zu main)
+
+---
+
+## Regeln
+
+- Frag an jedem Phasenübergang nach Feedback
+- Halte den Status im bestehenden Repo aktuell
+- Wenn etwas unklar ist: frag nach — rate nicht
+- Zeig Zwischenergebnisse, damit der User früh korrigieren kann
+- Lies `docs/lessons.md` zu Beginn jeder Phase auf relevante Muster
+- Wenn eine Phase Korrekturen brauchte: halte die Lektion in `docs/lessons.md` fest
+- Wenn etwas schiefläuft: STOPP und neu planen — nicht weiterpushen
+- Geh nie davon aus, dass bestehender Code falsch ist — verstehe ihn zuerst
+- Refactore nichts außerhalb des Scopes des Features


### PR DESCRIPTION
## Summary

Extends the workflow so the same agents and phase structure that power `/kickoff` can also be used to add features and improvements to **existing projects**.

## What's new

- **`commands/feature.md`** — `/feature` command, explicitly invoked
- **`skills/feature/SKILL.md`** — auto-triggered when the user says things like "füge X hinzu" or "I want to add..."
- **`skills/feature/README.md`** — install instructions + comparison table

## Key differences from `/kickoff`

| | `/kickoff` | `/feature` |
|---|---|---|
| Phase 1 | Setup (new repo, board, milestones) | Context (read existing codebase + lessons.md) |
| Phase 3 Design | Always | Only if UI changes |
| Phase 4 Architecture | Always | Only for significant features |
| Developer | Start fresh | Read existing patterns first |
| QA | Standard | + Regression testing |

## Also updated

- `commands/kickoff.md` — clarified "new project from scratch" + pointer to `/feature`
- `README.md` — two-workflow diagram, updated setup + start sections

## Install

```bash
cp commands/feature.md ~/.claude/commands/
mkdir -p ~/.claude/skills/feature
cp skills/feature/SKILL.md ~/.claude/skills/feature/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)