### PR TITLE
Introduce Source-of-Truth system and phase-based DoD checklists

### DIFF
--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -38,6 +38,8 @@ When invoked:
 - Release and acceptance criteria defined with QA/Dev
 - Feedback loops active (support, CS, reviews, NPS, interviews)
 - Measurable business impact (activation, retention, revenue, cost)
+- **Business Rules als SoT-Einträge (BR-xxx) in `docs/sot/` dokumentiert**
+- **User Journeys als SoT-Einträge (UJ-xxx) in `docs/sot/` dokumentiert**
 - **Phase Handoff Document created in `docs/handoffs/01_requirements.md`**
 
 ## Core Responsibilities

--- a/agents/tech-lead.md
+++ b/agents/tech-lead.md
@@ -34,6 +34,8 @@ When invoked:
 - Requirements clarified; edge cases identified
 - Non-functional requirements set (performance, availability, privacy)
 - Architecture decision recorded (ADR when applicable)
+- **Architektur-Entscheidungen als SoT-Einträge (ADR-xxx) in `docs/sot/` dokumentiert**
+- **API Contracts als SoT-Einträge (API-xxx) in `docs/sot/` dokumentiert**
 - API/contracts defined; backward compatibility considered
 - Logging/monitoring/alerting included
 - Feature flags and safe rollout plan present

--- a/commands/feature.md
+++ b/commands/feature.md
@@ -45,37 +45,71 @@ Sobald ich geantwortet habe, starte den Workflow:
 ### Phase 1: Context (product-manager)
 - Lies die bestehende Codebase: Struktur, Patterns, Konventionen
 - Prüfe `docs/lessons.md` auf relevante Learnings aus vergangenen Phasen
+- Prüfe `docs/sot/` auf bestehende SoT-Einträge (BR-xxx, UJ-xxx, API-xxx, ADR-xxx) die relevant sein könnten
 - Schaue offene GitHub Issues durch, um Dopplungen zu vermeiden
 - Verstehe Tech Stack, Design System und Komponentenbibliothek
 - Fasse deine Erkenntnisse kurz zusammen und hol mein OK bevor du weitergehst
+
+#### DoD Phase 1:
+- [ ] Bestehende Codebase, Patterns und Konventionen verstanden
+- [ ] Relevante SoT-Einträge identifiziert
+- [ ] Offene Issues auf Dopplungen geprüft
+- [ ] Zusammenfassung erstellt
+- [ ] Human-Approval erhalten
 
 ### Phase 2: Requirements (product-manager + ux-researcher)
 - Erarbeite im Dialog mit mir das Feature / die Verbesserung
 - Schreibe neue GitHub Issues (zum bestehenden Board, passendem Milestone)
 - User Story, Akzeptanzkriterien, Priorität (Must/Should/Could)
 - Frag aktiv nach, wenn Infos fehlen
-- **Erstelle am Ende `docs/handoffs/01_requirements.md` oder aktualisiere es. Inhalt: Zielgruppe, Scope, Liste der Kern-Features (mit Issue-Links) und die wichtigsten Erfolgsmetriken.**
+- **Erstelle neue oder aktualisiere bestehende SoT-Einträge (BR-xxx, UJ-xxx) in `docs/sot/` wenn das Feature neue Regeln oder Journeys einführt**
+- **Erstelle am Ende `docs/handoffs/01_requirements.md` oder aktualisiere es. Inhalt: Zielgruppe, Scope, Liste der Kern-Features (mit Issue-Links), Erfolgsmetriken und Referenzen auf SoT-IDs. Kompakt halten — Details in SoT auslagern.**
+
+#### DoD Phase 2:
+- [ ] Neue GitHub Issues mit Akzeptanzkriterien erstellt
+- [ ] Neue/aktualisierte SoT-Einträge (BR-xxx, UJ-xxx) wo nötig
+- [ ] `docs/handoffs/01_requirements.md` erstellt/aktualisiert
+- [ ] Erfolgsmetriken definiert
+- [ ] STATUS.md aktualisiert
+- [ ] Human-Approval erhalten
 
 ### Phase 3: Design (product-designer — nur wenn UI-Änderungen)
 - Nur ausführen wenn das Feature UI-Änderungen beinhaltet
-- **Lies zuerst `docs/handoffs/01_requirements.md`, um den Kontext zu verstehen.**
+- **Lies zuerst `docs/handoffs/01_requirements.md` und relevante SoT-Einträge (UJ-xxx), um den Kontext zu verstehen.**
 - Analysiere bestehende Screens auf Konsistenz — neues Design muss passen
 - Generiere Mockups mit Nano Banana, die zum bestehenden Design System passen
 - Lade Mockups als Bildanhänge direkt in die jeweiligen GitHub Issues hoch
 - Hol mein Feedback ein bevor du weitermachst
 - **Erstelle am Ende `docs/handoffs/02_design.md` oder aktualisiere es. Inhalt: Liste aller Screens/Komponenten, Design-Entscheidungen (Farben, Stil) und Links zu den Issues mit den Mockups.**
 
+#### DoD Phase 3:
+- [ ] Bestehende Screens auf Konsistenz analysiert
+- [ ] Mockups generiert und in Issues hochgeladen
+- [ ] Design-Feedback eingeholt und eingearbeitet
+- [ ] `docs/handoffs/02_design.md` erstellt/aktualisiert
+- [ ] STATUS.md aktualisiert
+- [ ] Human-Approval erhalten
+
 ### Phase 4: Architektur (tech-lead — nur bei größeren Features)
 - Nur ausführen wenn das Feature neue APIs, Datenmodell-Änderungen oder neue Services braucht
-- **Lies zuerst `docs/handoffs/01_requirements.md` und `docs/handoffs/02_design.md`.**
+- **Lies zuerst `docs/handoffs/01_requirements.md`, `docs/handoffs/02_design.md` und bestehende SoT-Einträge (ADR-xxx, API-xxx).**
 - Bewerte den Impact auf die bestehende Architektur
+- **Erstelle neue oder aktualisiere bestehende SoT-Einträge (ADR-xxx, API-xxx) in `docs/sot/`**
 - Ergänze das bestehende ADR oder erstelle ein Addendum — kein neues ADR von Grund auf
 - Identifiziere Integrationspunkte und Risiken
 - Hol mein Feedback ein bevor du weitermachst
-- **Erstelle am Ende `docs/handoffs/03_architecture.md` oder aktualisiere es. Inhalt: Gewählter Stack, Datenmodell (Grobkonzept), Architektur-Entscheidungen und externe Abhängigkeiten.**
+- **Erstelle am Ende `docs/handoffs/03_architecture.md` oder aktualisiere es. Inhalt: Gewählter Stack, Datenmodell, Referenzen auf ADR-xxx/API-xxx SoT-Einträge und externe Abhängigkeiten.**
+
+#### DoD Phase 4:
+- [ ] Impact auf bestehende Architektur bewertet
+- [ ] SoT-Einträge (ADR-xxx, API-xxx) erstellt/aktualisiert
+- [ ] `docs/handoffs/03_architecture.md` erstellt/aktualisiert
+- [ ] Integrationspunkte und Risiken identifiziert
+- [ ] STATUS.md aktualisiert
+- [ ] Human-Approval erhalten
 
 ### Phase 5: Implementierung (developer)
-- **Lies zuerst ALLE Dokumente in `docs/handoffs/`, um das Gesamtbild zu haben, bevor du Code schreibst.**
+- **Lies zuerst ALLE Dokumente in `docs/handoffs/` und `docs/sot/`, um das Gesamtbild zu haben, bevor du Code schreibst.**
 - Lies zuerst die bestehenden Code-Patterns, bevor du mit dem Schreiben beginnst
 - Issue auf "In Progress" im GitHub Projects Board setzen
 - Feature-Branch pro Issue: `feat/<issue-id>-<kurzbeschreibung>`
@@ -83,8 +117,17 @@ Sobald ich geantwortet habe, starte den Workflow:
 - Nutze bestehende Design-System-Komponenten statt neue zu erfinden
 - PR erstellen mit `Closes #<issue-id>` und Screenshots für UI-Änderungen
 - Issue auf "Review" setzen wenn der PR offen ist
+- Referenziere relevante SoT-IDs in Code-Kommentaren wo es das Verständnis fördert
+
+#### DoD Phase 5:
+- [ ] Alle Tickets abgearbeitet
+- [ ] Feature-Branches + PRs erstellt
+- [ ] Bestehende Patterns und Konventionen eingehalten
+- [ ] SoT-Constraints (BR-xxx) im Code berücksichtigt
+- [ ] STATUS.md aktualisiert
 
 ### Phase 6: QA (qa-lead)
+- **Lies die relevanten SoT-Einträge (insbesondere BR-xxx Constraints) um gegen die richtigen Kriterien zu prüfen.**
 - Reviewe den PR gegen die Akzeptanzkriterien im verlinkten Issue
 - Regressionstests: Stelle sicher, dass bestehende Funktionen noch funktionieren
 - Besonders Acht geben auf Integrationspunkte mit bestehendem Code
@@ -93,10 +136,24 @@ Sobald ich geantwortet habe, starte den Workflow:
 - Erstelle eine Release-Checkliste
 - Hol mein finales OK bevor deployed wird
 
+#### DoD Phase 6:
+- [ ] PRs gegen Akzeptanzkriterien und SoT-Constraints geprüft
+- [ ] Regressionstests bestanden
+- [ ] Integrationspunkte geprüft
+- [ ] Release-Checkliste erstellt
+- [ ] STATUS.md aktualisiert
+- [ ] Human-Approval erhalten
+
 ### Phase 7: Deployment (tech-lead)
 - Nutze die bestehende Vercel-Konfiguration (oder alternatives Target)
 - Jeder PR bekommt automatisch eine Preview-URL
 - Deploye nach meinem finalen OK (Merge zu main)
+
+#### DoD Phase 7:
+- [ ] Deployment-Konfiguration geprüft
+- [ ] Finales OK eingeholt
+- [ ] Erfolgreiches Deployment bestätigt
+- [ ] STATUS.md auf "done" gesetzt
 
 ---
 

--- a/commands/kickoff.md
+++ b/commands/kickoff.md
@@ -50,15 +50,37 @@ Sobald ich geantwortet habe, starte den Workflow:
 - Richte ein GitHub Projects Board ein (Backlog → Ready → In Progress → Review → Done)
 - Definiere Milestones: Discovery → Design → Architecture → Implementation → QA → Launch
 - Erstelle `docs/lessons.md` für phasenübergreifende Lernmuster (wird nach Phasenproblemen befüllt)
+- Erstelle `docs/sot/` Verzeichnis (kopiere `docs/sot/TEMPLATE.md` als Vorlage für Source-of-Truth-Einträge)
+- Erstelle STATUS.md mit Phase-Gate-Tabelle (aktuelle Phase, Scope, Fortschritt, SoT-Register)
+
+#### DoD Phase 1:
+- [ ] GitHub Repo mit Struktur erstellt
+- [ ] Projects Board eingerichtet (5 Spalten)
+- [ ] Milestones definiert
+- [ ] `docs/lessons.md` angelegt
+- [ ] `docs/sot/` Verzeichnis mit TEMPLATE.md angelegt
+- [ ] STATUS.md mit Phase-Gate-Tabelle erstellt
+- [ ] Human-Approval erhalten
 
 ### Phase 2: Requirements (product-manager + ux-researcher)
 - Erarbeite im Dialog mit mir die Kernfeatures
 - Schreibe für jedes Feature ein GitHub Issue mit User Story, Akzeptanzkriterien und Priorität (Must/Should/Could)
 - Frag aktiv nach, wenn Infos fehlen
-- **Erstelle am Ende `docs/handoffs/01_requirements.md`. Dieses Dokument muss enthalten: Zielgruppe, Scope, Liste der Kern-Features (mit Issue-Links) und die wichtigsten Erfolgsmetriken.**
+- **Dokumentiere harte Business Rules als SoT-Einträge (BR-xxx) in `docs/sot/`** (z.B. Limits, Constraints, Geschäftsregeln)
+- **Dokumentiere Kern-User-Journeys als SoT-Einträge (UJ-xxx) in `docs/sot/`**
+- **Erstelle am Ende `docs/handoffs/01_requirements.md`. Inhalt: Zielgruppe, Scope, Liste der Kern-Features (mit Issue-Links), Erfolgsmetriken und Referenzen auf SoT-IDs. Halte das Dokument kompakt — Details gehören in die SoT-Einträge.**
+
+#### DoD Phase 2:
+- [ ] Alle Features als GitHub Issues mit Akzeptanzkriterien
+- [ ] Business Rules als SoT-Einträge (BR-xxx) dokumentiert
+- [ ] Kern-User-Journeys als SoT-Einträge (UJ-xxx) dokumentiert
+- [ ] `docs/handoffs/01_requirements.md` erstellt (kompakt, Details in SoT ausgelagert)
+- [ ] Erfolgsmetriken definiert
+- [ ] STATUS.md aktualisiert
+- [ ] Human-Approval erhalten
 
 ### Phase 3: Design (product-designer)
-- **Lies zuerst `docs/handoffs/01_requirements.md`, um den Kontext zu verstehen.**
+- **Lies zuerst `docs/handoffs/01_requirements.md` und relevante SoT-Einträge (UJ-xxx), um den Kontext zu verstehen.**
 - Erstelle eine Screen-Inventur basierend auf den Issues
 - Generiere UI-Mockups mit Nano Banana Pro
 - Lade die Mockups als Bildanhänge direkt in die jeweiligen GitHub Issues hoch
@@ -66,23 +88,49 @@ Sobald ich geantwortet habe, starte den Workflow:
 - Hol mein Feedback ein bevor du weitermachst
 - **Erstelle am Ende `docs/handoffs/02_design.md`. Inhalt: Liste aller Screens/Komponenten, Design-Entscheidungen (Farben, Stil) und Links zu den Issues mit den Mockups.**
 
+#### DoD Phase 3:
+- [ ] Screen-Inventur basierend auf Issues erstellt
+- [ ] Mockups generiert und in Issues hochgeladen
+- [ ] Design-Feedback eingeholt und eingearbeitet
+- [ ] `docs/handoffs/02_design.md` erstellt
+- [ ] STATUS.md aktualisiert
+- [ ] Human-Approval erhalten
+
 ### Phase 4: Architektur (tech-lead)
-- **Lies zuerst `docs/handoffs/01_requirements.md` und `docs/handoffs/02_design.md`.**
+- **Lies zuerst `docs/handoffs/01_requirements.md`, `docs/handoffs/02_design.md` und alle relevanten SoT-Einträge.**
 - Schlage einen Tech Stack vor basierend auf Requirements und Scope
-- Erstelle ein Architecture Decision Record (ADR) im Repo
+- **Dokumentiere Architektur-Entscheidungen als SoT-Einträge (ADR-xxx) in `docs/sot/`**
+- **Dokumentiere API Contracts als SoT-Einträge (API-xxx) in `docs/sot/`**
 - Kläre offene technische Fragen mit mir
-- **Erstelle am Ende `docs/handoffs/03_architecture.md`. Inhalt: Gewählter Stack, Datenmodell (Grobkonzept), Architektur-Entscheidungen und externe Abhängigkeiten.**
+- **Erstelle am Ende `docs/handoffs/03_architecture.md`. Inhalt: Gewählter Stack, Datenmodell (Grobkonzept), Referenzen auf ADR-xxx/API-xxx SoT-Einträge und externe Abhängigkeiten.**
+
+#### DoD Phase 4:
+- [ ] Tech Stack vorgeschlagen und abgestimmt
+- [ ] Architektur-Entscheidungen als SoT-Einträge (ADR-xxx) erstellt
+- [ ] API Contracts als SoT-Einträge (API-xxx) dokumentiert
+- [ ] `docs/handoffs/03_architecture.md` erstellt
+- [ ] STATUS.md aktualisiert
+- [ ] Human-Approval erhalten
 
 ### Phase 5: Implementierung (developer)
-- **Lies zuerst ALLE Dokumente in `docs/handoffs/`, um das Gesamtbild zu verstehen, bevor du Code schreibst.**
+- **Lies zuerst ALLE Dokumente in `docs/handoffs/` und `docs/sot/`, um das Gesamtbild zu verstehen, bevor du Code schreibst.**
 - Arbeite die Tickets mit Design ab, eins nach dem anderen
 - Issue auf "In Progress" im GitHub Projects Board setzen, bevor die Arbeit beginnt
 - Feature-Branch pro Issue: `feat/<issue-id>-<kurzbeschreibung>`
 - PR erstellen mit `Closes #<issue-id>` in der Beschreibung und Screenshots für UI-Änderungen
 - Issue auf "Review" setzen, wenn der PR geöffnet wird
 - Nutze die v0-generierten Komponenten aus Phase 3
+- Referenziere relevante SoT-IDs in Code-Kommentaren wo es das Verständnis fördert (z.B. `// BR-003: Max 3 Projekte pro Free-User`)
+
+#### DoD Phase 5:
+- [ ] Alle Tickets mit Design abgearbeitet
+- [ ] Feature-Branches + PRs erstellt mit `Closes #<issue-id>`
+- [ ] Code folgt bestehenden Patterns und Konventionen
+- [ ] SoT-Constraints (BR-xxx) im Code berücksichtigt
+- [ ] STATUS.md aktualisiert
 
 ### Phase 6: QA (qa-lead)
+- **Lies die relevanten SoT-Einträge (insbesondere BR-xxx Constraints) um gegen die richtigen Kriterien zu prüfen.**
 - Reviewe den PR gegen die Akzeptanzkriterien im verlinkten Issue
 - Feedback als PR-Kommentare, bei Problemen "Changes requested"
 - PR approven wenn alle Kriterien erfüllt sind
@@ -90,9 +138,22 @@ Sobald ich geantwortet habe, starte den Workflow:
 - Prüfe Edge Cases, Responsive, Accessibility
 - Erstelle eine Release-Checkliste
 
+#### DoD Phase 6:
+- [ ] PRs gegen Akzeptanzkriterien und SoT-Constraints geprüft
+- [ ] Edge Cases, Responsive, Accessibility getestet
+- [ ] Release-Checkliste erstellt
+- [ ] STATUS.md aktualisiert
+- [ ] Human-Approval erhalten
+
 ### Phase 7: Deployment (tech-lead)
 - Konfiguriere Vercel (oder alternatives Target)
 - Deploye nach meinem finalen OK
+
+#### DoD Phase 7:
+- [ ] Deployment-Konfiguration geprüft
+- [ ] Finales OK eingeholt
+- [ ] Erfolgreiches Deployment bestätigt
+- [ ] STATUS.md auf "done" gesetzt
 
 ---
 

--- a/docs/sot/TEMPLATE.md
+++ b/docs/sot/TEMPLATE.md
@@ -1,0 +1,16 @@
+# [ID-PREFIX]-[NNN]: [Titel]
+
+**Status:** active | deprecated | superseded by [ID]
+**Erstellt:** Phase [X], Issue #[Y]
+
+## Regel / Beschreibung
+
+[Klare, eindeutige Formulierung der Regel, Entscheidung oder des Contracts]
+
+## Begründung
+
+[Warum wurde diese Entscheidung getroffen? Welche Alternativen wurden erwogen?]
+
+## Auswirkungen
+
+[Welche Komponenten, Features oder Agents sind betroffen?]

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,53 @@
+# Hooks
+
+Automatisierte Event-Handler für Claude Code Sessions. Hooks injizieren Kontext oder validieren Zustände bei bestimmten Events.
+
+## Verfügbare Hooks
+
+### `session-start.sh` — SessionStart Hook
+
+Wird beim Start jeder Claude Code Session ausgeführt und injiziert automatisch den richtigen Projektkontext:
+
+- **Phase & Scope** aus STATUS.md
+- **Lessons Learned** Hinweis (wenn vorhanden)
+- **SoT-Register** Zusammenfassung (Anzahl verfügbarer Einträge)
+- **Phase-spezifische Handoff-Hinweise** (welche Docs zuerst gelesen werden sollen)
+
+## Installation
+
+Kopiere die Hook-Konfiguration in die `.claude/settings.json` deines Ziel-Projekts:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "sh hooks/session-start.sh"
+      }
+    ]
+  }
+}
+```
+
+## Voraussetzungen
+
+- POSIX-kompatible Shell (sh/bash/zsh)
+- Keine externen Abhängigkeiten
+- `STATUS.md` im Projekt-Root (wird von Phase 1/Setup erstellt)
+
+## Eigene Hooks erstellen
+
+Hooks sind Shell-Scripts die JSON auf stdout ausgeben:
+
+```json
+{
+  "hookEventName": "SessionStart",
+  "additionalContext": "Dein injizierter Kontext hier."
+}
+```
+
+Unterstützte Events:
+- `SessionStart` — Wird beim Session-Start ausgeführt
+- `UserPromptSubmit` — Wird vor Verarbeitung eines User-Prompts ausgeführt
+- `Stop` — Wird am Ende einer Session ausgeführt

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# hooks/session-start.sh — Automatischer Kontext-Loader für Claude Code Sessions
+# Injiziert phase-spezifischen Kontext beim Session-Start.
+set -euo pipefail
+
+CONTEXT=""
+
+# 1. Aktuelle Phase und Scope aus STATUS.md lesen
+PHASE=""
+SCOPE=""
+if [ -f "STATUS.md" ]; then
+  PHASE=$(grep -oP 'Aktuelle Phase: \K\w+' STATUS.md 2>/dev/null || echo "")
+  SCOPE=$(grep -oP 'Scope: \K\w+' STATUS.md 2>/dev/null || echo "")
+  if [ -n "$PHASE" ]; then
+    CONTEXT="Phase: $PHASE"
+    [ -n "$SCOPE" ] && CONTEXT="$CONTEXT | Scope: $SCOPE"
+    CONTEXT="$CONTEXT."
+  fi
+fi
+
+# 2. Lessons learned referenzieren (nicht komplett laden — nur Hinweis)
+if [ -f "docs/lessons.md" ]; then
+  LESSON_COUNT=$(wc -l < docs/lessons.md 2>/dev/null || echo "0")
+  if [ "$LESSON_COUNT" -gt 0 ]; then
+    CONTEXT="$CONTEXT Lessons learned vorhanden ($LESSON_COUNT Zeilen) — lies docs/lessons.md zu Beginn."
+  fi
+fi
+
+# 3. SoT-Register zusammenfassen
+if [ -d "docs/sot" ]; then
+  SOT_COUNT=$(find docs/sot -name "*.md" ! -name "TEMPLATE.md" 2>/dev/null | wc -l)
+  if [ "$SOT_COUNT" -gt 0 ]; then
+    CONTEXT="$CONTEXT $SOT_COUNT SoT-Eintraege in docs/sot/ — referenziere per ID (BR-xxx, UJ-xxx, API-xxx, ADR-xxx)."
+  fi
+fi
+
+# 4. Phase-spezifische Handoff-Hinweise
+case "$PHASE" in
+  setup)
+    CONTEXT="$CONTEXT Erstelle Repo, Board, Milestones, docs/sot/ und STATUS.md." ;;
+  requirements)
+    CONTEXT="$CONTEXT Erstelle Issues + SoT-Eintraege (BR-xxx, UJ-xxx). Handoff: docs/handoffs/01_requirements.md." ;;
+  design)
+    CONTEXT="$CONTEXT Lies docs/handoffs/01_requirements.md + relevante SoT-Eintraege vor dem Design." ;;
+  architecture)
+    CONTEXT="$CONTEXT Lies docs/handoffs/01+02. Erstelle ADR-xxx und API-xxx SoT-Eintraege." ;;
+  implementation)
+    CONTEXT="$CONTEXT Lies ALLE docs/handoffs/ und docs/sot/. Code erst nach Kontext-Verstaendnis." ;;
+  qa)
+    CONTEXT="$CONTEXT Pruefe gegen Akzeptanzkriterien in Issues und SoT-Constraints (BR-xxx)." ;;
+  deployment)
+    CONTEXT="$CONTEXT Deployment-Konfiguration pruefen. Finales OK einholen." ;;
+esac
+
+# Nur ausgeben wenn Kontext vorhanden
+if [ -n "$CONTEXT" ]; then
+  # Escape quotes for JSON
+  CONTEXT=$(echo "$CONTEXT" | sed 's/"/\\"/g')
+  printf '{"hookEventName":"SessionStart","additionalContext":"%s"}\n' "$CONTEXT"
+fi

--- a/skills/sot-builder/SKILL.md
+++ b/skills/sot-builder/SKILL.md
@@ -1,0 +1,34 @@
+# SoT-Builder
+
+Erstelle und verwalte Source-of-Truth-Einträge im `docs/sot/`-Verzeichnis.
+
+## Wann nutzen
+
+- Wenn eine Business Rule, User Journey, API Contract oder Architektur-Entscheidung formalisiert werden soll
+- Während Phase 2 (Requirements): BR-xxx und UJ-xxx Einträge erstellen
+- Während Phase 4 (Architektur): ADR-xxx und API-xxx Einträge erstellen
+- Wenn bestehende Entscheidungen aktualisiert oder als deprecated markiert werden sollen
+
+## ID-Prefixe
+
+| Prefix | Typ | Wann erstellen |
+|--------|-----|----------------|
+| `BR-xxx` | Business Rule | Phase 2 — harte Constraints, Geschäftsregeln |
+| `UJ-xxx` | User Journey | Phase 2 — kritische Nutzerpfade |
+| `API-xxx` | API/Data Contract | Phase 4 — Schnittstellenbeschreibungen |
+| `ADR-xxx` | Architecture Decision Record | Phase 4 — technische Entscheidungen |
+
+## Vorgehen
+
+1. **Nächste freie ID ermitteln**: Prüfe `docs/sot/` auf bestehende Einträge des gewählten Typs. Die nächste Nummer ist `max + 1`, beginnend bei 001.
+2. **Template ausfüllen**: Kopiere `docs/sot/TEMPLATE.md` und fülle alle Felder aus.
+3. **Datei erstellen**: Speichere als `docs/sot/[ID].md` (z.B. `docs/sot/BR-001.md`).
+4. **STATUS.md aktualisieren**: Trage die neue ID in das SoT-Register in STATUS.md ein.
+
+## Regeln
+
+- Jeder Eintrag hat genau eine eindeutige ID
+- IDs werden nie wiederverwendet — deprecated Einträge bleiben bestehen
+- Bei Ablösung: alten Eintrag auf `superseded by [neue ID]` setzen
+- Halte Einträge kompakt (max. 500 Tokens pro Eintrag)
+- Referenziere SoT-IDs in Handoff-Docs, Issues und Code-Kommentaren


### PR DESCRIPTION
## Summary

This PR establishes a structured Source-of-Truth (SoT) system for managing critical project decisions and constraints across all workflow phases, along with Definition-of-Done (DoD) checklists for each phase. The changes introduce a new documentation pattern that keeps handoff documents lean while centralizing detailed specifications in versioned SoT entries.

## Key Changes

### Documentation Structure
- **New SoT system** (`docs/sot/`): Centralized registry for Business Rules (BR-xxx), User Journeys (UJ-xxx), API Contracts (API-xxx), and Architecture Decisions (ADR-xxx)
- **SoT Template** (`docs/sot/TEMPLATE.md`): Standardized format for all SoT entries with status tracking and deprecation support
- **STATUS.md**: New phase-gate tracking document with current phase, scope, progress, and SoT register
- **SoT-Builder skill** (`skills/sot-builder/SKILL.md`): Guidance for creating and managing SoT entries with ID conventions and lifecycle rules

### Workflow Updates
Both `commands/kickoff.md` (new project) and `commands/feature.md` (feature development) now include:
- **Phase 1**: Setup of `docs/sot/` directory and STATUS.md
- **Phase 2**: Creation of BR-xxx and UJ-xxx SoT entries for business rules and user journeys
- **Phase 3**: Design phase reads relevant SoT entries before creating mockups
- **Phase 4**: Creation of ADR-xxx and API-xxx SoT entries; handoff docs reference SoT IDs instead of duplicating details
- **Phase 5**: Developers reference SoT-IDs in code comments; constraints (BR-xxx) enforced during implementation
- **Phase 6**: QA validates against SoT constraints (BR-xxx) in addition to acceptance criteria
- **Phase 7**: Deployment confirmation and STATUS.md finalization

### Definition-of-Done Checklists
Each phase now has explicit DoD criteria including:
- Artifact creation/updates (Issues, Docs, SoT entries)
- SoT constraint compliance
- STATUS.md updates
- Human approval gates

### Automation
- **SessionStart Hook** (`hooks/session-start.sh`): Automatically injects phase context, lessons learned, and SoT register summary at the start of each Claude Code session
- **hooks/README.md**: Documentation for hook system and custom hook creation

### Agent Updates
- **product-manager.md**: Added requirement to document Business Rules as SoT entries
- **tech-lead.md**: Added requirement to document Architecture Decisions as SoT entries

## Implementation Details

- SoT entries use prefixed IDs (BR-001, UJ-001, API-001, ADR-001) with independent numbering per type
- Deprecated entries remain in the registry with `superseded by [ID]` status for traceability
- Handoff documents now reference SoT entries rather than duplicating specifications, keeping them compact
- Code comments can reference SoT-IDs (e.g., `// BR-003: Max 3 projects per user`) to link implementation to business rules
- STATUS.md serves as the single source for current phase and project state, enabling automated context injection via hooks

https://claude.ai/code/session_01CyrcH2tCkFHZmwSh29nTjM