### PR TITLE
chore: update workflow kit source reference

### DIFF
--- a/templates/product/PRODUCT.md
+++ b/templates/product/PRODUCT.md
@@ -1,6 +1,6 @@
 ---
 workflow_kit:
-  source: andreasspiegler/claude-code-product-workflow
+  source: andreasspiegler/product-workflow-kit
   version: "{{WORKFLOW_KIT_VERSION}}"
   installed_at: "{{DATE}}"
 ---


### PR DESCRIPTION
## Summary
- update the generated product template to record andreasspiegler/product-workflow-kit as its workflow-kit source

## Validation
- git diff --check

This follows the repository rename from claude-code-product-workflow to product-workflow-kit.