### PR TITLE
feat: add requirements quality skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The Git repository is the source of the kit. Each product uses a reviewed local 
 | --- | --- |
 | [`kickoff`](skills/kickoff/SKILL.md) | Starting a new product and creating credible, pinned product context. |
 | [`feature`](skills/feature/SKILL.md) | Extending an existing product from its current context and risk profile. |
+| [`requirements-quality`](skills/requirements-quality/SKILL.md) | Clarifying complex, high-impact, or uncertain requirements directly in their issue. |
 | [`product-design`](skills/product-design/SKILL.md) | User journeys, interaction direction, system decisions, UX/a11y review, and optional Impeccable usage. |
 | [`quality-release`](skills/quality-release/SKILL.md) | Proportionate tests, release readiness, rollout risk, and outcome checks. |
 | [`sot-builder`](skills/sot-builder/SKILL.md) | V2 compatibility name for durable decision and contract records. |
@@ -72,7 +73,8 @@ Install only the skills a product needs. The following examples use project-loca
 ```bash
 mkdir -p .claude/skills
 cp -R "$WORKFLOW_KIT/skills/kickoff" "$WORKFLOW_KIT/skills/feature" \
-  "$WORKFLOW_KIT/skills/product-design" "$WORKFLOW_KIT/skills/quality-release" \
+  "$WORKFLOW_KIT/skills/requirements-quality" "$WORKFLOW_KIT/skills/product-design" \
+  "$WORKFLOW_KIT/skills/quality-release" \
   .claude/skills/
 ```
 
@@ -83,7 +85,8 @@ Use the role briefs only when the team wants Claude Code subagents, by adapting 
 ```bash
 mkdir -p .agents/skills
 cp -R "$WORKFLOW_KIT/skills/kickoff" "$WORKFLOW_KIT/skills/feature" \
-  "$WORKFLOW_KIT/skills/product-design" "$WORKFLOW_KIT/skills/quality-release" \
+  "$WORKFLOW_KIT/skills/requirements-quality" "$WORKFLOW_KIT/skills/product-design" \
+  "$WORKFLOW_KIT/skills/quality-release" \
   .agents/skills/
 ```
 
@@ -94,7 +97,8 @@ Keep `AGENTS.md` in the product root. Configure only the Codex-specific agent, p
 ```bash
 mkdir -p .opencode/skills
 cp -R "$WORKFLOW_KIT/skills/kickoff" "$WORKFLOW_KIT/skills/feature" \
-  "$WORKFLOW_KIT/skills/product-design" "$WORKFLOW_KIT/skills/quality-release" \
+  "$WORKFLOW_KIT/skills/requirements-quality" "$WORKFLOW_KIT/skills/product-design" \
+  "$WORKFLOW_KIT/skills/quality-release" \
   .opencode/skills/
 ```
 

--- a/skills/requirements-quality/SKILL.md
+++ b/skills/requirements-quality/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: requirements-quality
+description: >-
+  Improve complex, high-impact, or uncertain product requirements before
+  implementation. Use when acceptance criteria are ambiguous, behavior has
+  important conditions or failure cases, assumptions are hidden, or a decision
+  needs clearer evidence. Keep the GitHub Issue as the work record; do not use
+  for routine low-risk changes that are already clear.
+---
+
+# Requirements quality
+
+Use this skill to clarify a decision, not to impose a formal specification process.
+
+## Start from evidence
+
+Read `PRODUCT.md`, the active issue, relevant `DESIGN.md` guidance, linked decisions, and available evidence. State what is unknown. Do not invent users, constraints, metrics, approval, research findings, or implementation details.
+
+First decide whether this skill adds value. Use it for consequential ambiguity, a new or altered behavior boundary, material user harm on failure, or acceptance criteria that cannot yet be verified. For a clear, low-risk change, improve the issue directly and stop.
+
+## Find the requirement risks
+
+Check the issue for:
+
+- vague or unobservable language such as “fast”, “simple”, or “scalable”;
+- hidden assumptions, undefined terms, and missing ownership or boundaries;
+- implementation bias that states a solution instead of the required outcome;
+- missing unhappy paths, permissions, state transitions, or recovery behavior;
+- acceptance criteria that cannot be observed or tested;
+- relevant non-functional constraints: privacy, security, accessibility, reliability, performance, or compatibility.
+
+Turn each material gap into a focused question, a measurable constraint, or an explicit assumption. Ask for a human decision when resolving the gap would materially alter scope, direction, risk, or cost.
+
+## Structure only what helps
+
+Draft the result for the active GitHub Issue. Apply it to the issue only with explicit approval. Add or improve, as relevant:
+
+1. The intended outcome, user, and current scope.
+2. Explicit non-goals, assumptions, dependencies, and open questions.
+3. Observable acceptance criteria, including required error or edge behavior.
+4. A measurable constraint when a non-functional requirement matters.
+5. Links to the evidence and decisions that support the requirement.
+
+Use EARS-style wording only when it clarifies conditional behavior:
+
+- **Ubiquitous:** the system must always behave this way.
+- **Event-driven:** when an event occurs, the system must respond this way.
+- **State-driven:** while a state holds, the system must behave this way.
+- **Optional:** when a feature or condition is enabled, the system must behave this way.
+- **Unwanted:** if an unwanted condition occurs, the system must protect or recover this way.
+
+Use Given/When/Then scenarios only for behavior where an example makes the criterion more testable. Cover both a representative success path and a material failure or edge path when that risk exists. Do not manufacture a fixed number of scenarios.
+
+## Finish the requirement work
+
+Summarize the clarified acceptance criteria, remaining uncertainty, and the next decision or implementation step. With approval, record the result in the issue. Update `PRODUCT.md`, `DESIGN.md`, or `docs/decisions/` only when the work creates durable product, experience, or contract guidance.
+
+Do not create a parallel `spec.md`, phase handoff, or status file. Do not contact stakeholders, collect research, create external issues, or make other external changes without explicit approval.


### PR DESCRIPTION
## Summary
- add an optional requirements-quality skill for complex, high-impact, or uncertain requirements
- keep the active GitHub Issue as the work record instead of creating a parallel specification file
- apply EARS and Given/When/Then selectively when they make behavior clearer and testable
- document the new skill in the portable runtime setup examples

Closes #14

## Validation
- skill-creator quick_validate.py
- git diff --check