### PR TITLE
feat: add project-local workflow installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,22 +51,28 @@ The role briefs in [`agents/`](agents/) are specialist perspectives, not an obli
 
 ## Start a product with a pinned kit version
 
-From the product repository, copy the shared context and record the kit revision that supplied it:
+From the workflow kit checkout, install the shared context and selected skills into an existing product repository:
 
 ```bash
-# WORKFLOW_KIT points to your reviewed local checkout of this repository
-cp -R "$WORKFLOW_KIT/templates/product/." .
-git -C "$WORKFLOW_KIT" rev-parse HEAD
-# Replace {{WORKFLOW_KIT_VERSION}} and {{DATE}} in PRODUCT.md with that value and today's date.
+./scripts/install.sh --target ../my-product --runtime claude
 ```
 
-Then fill the outcome, user, scope, non-goals, constraints, and success signal in `PRODUCT.md`. Start the first issue only after its acceptance criteria and the selected risk-reduction work are clear.
+The installer copies the product context, records the current kit Git commit and date in `PRODUCT.md`, and installs the five core skills locally. It refuses to overwrite existing context or skill files and never changes global configuration, hooks, plugins, permissions, or connectors.
+
+Choose a different or additional runtime deliberately:
+
+```bash
+./scripts/install.sh --target ../my-product --runtime codex --runtime opencode
+./scripts/install.sh --target ../my-product --runtime claude --skill kickoff --skill feature
+```
+
+Use `--kit-version <version>` only when installing from a non-Git kit archive or when pinning a specific release value. Then fill the outcome, user, scope, non-goals, constraints, and success signal in `PRODUCT.md`. Start the first issue only after its acceptance criteria and the selected risk-reduction work are clear.
 
 The product can deliberately upgrade later: review the newer kit version, update the local skill copy or symlink, and record the new version in `PRODUCT.md`.
 
-## Add the portable skills locally
+## Manual installation
 
-Install only the skills a product needs. The following examples use project-local copies so the product stays reproducible; symlinks are appropriate only when the project intentionally follows changes in a local kit checkout.
+Use the installer above for normal setup. The following project-local copy examples remain available for teams that need a deliberately custom installation; symlinks are appropriate only when the project intentionally follows changes in a local kit checkout.
 
 ### Claude Code
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,7 +141,11 @@ cp "$KIT_ROOT/templates/product/DESIGN.md" "$TARGET/DESIGN.md"
 cp "$KIT_ROOT/templates/product/docs/decisions/README.md" "$TARGET/docs/decisions/README.md"
 cp "$KIT_ROOT/templates/product/docs/decisions/TEMPLATE.md" "$TARGET/docs/decisions/TEMPLATE.md"
 
-escaped_version="$(printf '%s' "$KIT_VERSION" | sed 's/[&|]/\\&/g')"
+case "$KIT_VERSION" in
+  *$'\n'*|*$'\r'*) fail "kit version must not contain line breaks" ;;
+esac
+yaml_version="$(printf '%s' "$KIT_VERSION" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+escaped_version="$(printf '%s' "$yaml_version" | sed 's/[\\&|]/\\&/g')"
 escaped_date="$(date +%F | sed 's/[&|]/\\&/g')"
 product_tmp="$(mktemp "$TARGET/.product-workflow-kit.XXXXXX")"
 trap 'rm -f "$product_tmp"' EXIT

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/install.sh --target <product-directory> --runtime <claude|codex|opencode> [options]
+
+Install the Product Workflow Kit into an existing product directory. The script
+only writes project-local files. It never installs global skills, hooks,
+plugins, permissions, or connectors.
+
+Required:
+  --target <directory>       Existing product directory to receive the kit.
+  --runtime <name>           Runtime to configure; repeat for multiple runtimes.
+
+Options:
+  --skill <name>             Install one selected skill; repeat to choose several.
+                              Defaults to kickoff, feature, requirements-quality,
+                              product-design, and quality-release.
+  --kit-version <version>    Record an explicit kit version instead of the current
+                              Git commit.
+  --help                     Show this help.
+
+Examples:
+  scripts/install.sh --target ../my-product --runtime claude
+  scripts/install.sh --target ../my-product --runtime codex --runtime opencode
+  scripts/install.sh --target ../my-product --runtime claude --skill kickoff --skill feature
+EOF
+}
+
+fail() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+has_value() {
+  local value="$1"
+  local candidate
+  shift
+  for candidate in "$@"; do
+    [[ "$candidate" == "$value" ]] && return 0
+  done
+  return 1
+}
+
+KIT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+TARGET=""
+KIT_VERSION=""
+RUNTIMES=()
+REQUESTED_SKILLS=()
+DEFAULT_SKILLS=(kickoff feature requirements-quality product-design quality-release)
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      [[ $# -ge 2 ]] || fail "--target requires a directory"
+      TARGET="$2"
+      shift 2
+      ;;
+    --runtime)
+      [[ $# -ge 2 ]] || fail "--runtime requires a runtime name"
+      case "$2" in
+        claude|codex|opencode)
+          if [[ ${#RUNTIMES[@]} -eq 0 ]] || ! has_value "$2" "${RUNTIMES[@]}"; then
+            RUNTIMES+=("$2")
+          fi
+          ;;
+        *) fail "unsupported runtime: $2" ;;
+      esac
+      shift 2
+      ;;
+    --skill)
+      [[ $# -ge 2 ]] || fail "--skill requires a skill name"
+      if [[ ${#REQUESTED_SKILLS[@]} -eq 0 ]] || ! has_value "$2" "${REQUESTED_SKILLS[@]}"; then
+        REQUESTED_SKILLS+=("$2")
+      fi
+      shift 2
+      ;;
+    --kit-version)
+      [[ $# -ge 2 ]] || fail "--kit-version requires a value"
+      KIT_VERSION="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -n "$TARGET" ]] || fail "--target is required"
+[[ ${#RUNTIMES[@]} -gt 0 ]] || fail "at least one --runtime is required"
+[[ -d "$TARGET" ]] || fail "target directory does not exist: $TARGET"
+TARGET="$(cd "$TARGET" && pwd -P)"
+[[ "$TARGET" != "$KIT_ROOT" ]] || fail "target must be a product directory, not the kit checkout"
+
+if [[ ${#REQUESTED_SKILLS[@]} -gt 0 ]]; then
+  SKILLS=("${REQUESTED_SKILLS[@]}")
+else
+  SKILLS=("${DEFAULT_SKILLS[@]}")
+fi
+
+for skill in "${SKILLS[@]}"; do
+  [[ -f "$KIT_ROOT/skills/$skill/SKILL.md" ]] || fail "unknown skill: $skill"
+done
+
+if [[ -z "$KIT_VERSION" ]]; then
+  KIT_VERSION="$(git -C "$KIT_ROOT" rev-parse HEAD 2>/dev/null || true)"
+fi
+[[ -n "$KIT_VERSION" ]] || fail "could not determine kit version; pass --kit-version explicitly"
+
+CONTEXT_PATHS=(AGENTS.md CLAUDE.md PRODUCT.md DESIGN.md docs/decisions)
+for relative_path in "${CONTEXT_PATHS[@]}"; do
+  [[ ! -e "$TARGET/$relative_path" ]] || fail "refusing to overwrite existing $relative_path"
+done
+
+runtime_skill_dir() {
+  case "$1" in
+    claude) printf '.claude/skills' ;;
+    codex) printf '.agents/skills' ;;
+    opencode) printf '.opencode/skills' ;;
+  esac
+}
+
+for runtime in "${RUNTIMES[@]}"; do
+  skill_dir="$(runtime_skill_dir "$runtime")"
+  for skill in "${SKILLS[@]}"; do
+    [[ ! -e "$TARGET/$skill_dir/$skill" ]] || fail "refusing to overwrite existing $skill_dir/$skill"
+  done
+done
+
+mkdir -p "$TARGET/docs/decisions"
+cp "$KIT_ROOT/templates/product/AGENTS.md" "$TARGET/AGENTS.md"
+cp "$KIT_ROOT/templates/product/CLAUDE.md" "$TARGET/CLAUDE.md"
+cp "$KIT_ROOT/templates/product/DESIGN.md" "$TARGET/DESIGN.md"
+cp "$KIT_ROOT/templates/product/docs/decisions/README.md" "$TARGET/docs/decisions/README.md"
+cp "$KIT_ROOT/templates/product/docs/decisions/TEMPLATE.md" "$TARGET/docs/decisions/TEMPLATE.md"
+
+escaped_version="$(printf '%s' "$KIT_VERSION" | sed 's/[&|]/\\&/g')"
+escaped_date="$(date +%F | sed 's/[&|]/\\&/g')"
+product_tmp="$(mktemp "$TARGET/.product-workflow-kit.XXXXXX")"
+trap 'rm -f "$product_tmp"' EXIT
+sed \
+  -e "s|{{WORKFLOW_KIT_VERSION}}|$escaped_version|g" \
+  -e "s|{{DATE}}|$escaped_date|g" \
+  "$KIT_ROOT/templates/product/PRODUCT.md" > "$product_tmp"
+mv "$product_tmp" "$TARGET/PRODUCT.md"
+trap - EXIT
+
+for runtime in "${RUNTIMES[@]}"; do
+  skill_dir="$(runtime_skill_dir "$runtime")"
+  mkdir -p "$TARGET/$skill_dir"
+  for skill in "${SKILLS[@]}"; do
+    cp -R "$KIT_ROOT/skills/$skill" "$TARGET/$skill_dir/$skill"
+  done
+done
+
+printf 'Installed Product Workflow Kit %s into %s\n' "$KIT_VERSION" "$TARGET"
+printf 'Configured runtimes: %s\n' "${RUNTIMES[*]}"
+printf 'Installed skills: %s\n' "${SKILLS[*]}"
+printf 'No global configuration, hooks, plugins, permissions, or connectors were changed.\n'


### PR DESCRIPTION
## Summary
- add a project-local installer for Claude Code, Codex, and OpenCode
- pin the installed kit version and date in PRODUCT.md
- refuse to overwrite existing context or skill files
- avoid global configuration, hooks, plugins, permissions, and connectors
- retain manual setup instructions for deliberately custom installations

Closes #9

## Validation
- bash -n scripts/install.sh
- shellcheck scripts/install.sh
- temporary Claude, Codex, and OpenCode installation tests
- overwrite, duplicate-option, and self-installation protection tests
- git diff --check