### PR TITLE
feat: add selective test-first guidance

### DIFF
--- a/agents/developer.md
+++ b/agents/developer.md
@@ -15,6 +15,7 @@ Read `AGENTS.md`, the issue or pull request, relevant product and design context
 - Turn acceptance criteria into a small implementation plan and flag gaps before guessing.
 - Reuse established code and design patterns; keep the change within the agreed scope.
 - If an approved design proves technically unworkable, stop implementation, document the constraints and viable alternatives in the issue, and return the question to `product-design` before resuming.
+- Use a focused test-first loop when the `quality-release` assessment identifies deterministic, high-risk behavior that is clearer as an executable test than as a manual review.
 - Add or update the proportionate automated and manual verification evidence.
 - Make UI states, accessibility, error handling, and operational implications explicit where relevant.
 - Provide a pull request that links the issue, describes the change, records checks and limits, and includes visual evidence for UI changes when useful.

--- a/agents/tech-lead.md
+++ b/agents/tech-lead.md
@@ -16,6 +16,7 @@ Read the current product context, issue, existing architecture, and affected cod
 - Present proportionate options with trade-offs, including reversibility, operational cost, observability, and migration or rollback implications.
 - Record a durable decision or contract in `docs/decisions/` only when it needs to survive the current issue or pull request.
 - Define the verification and rollout evidence needed for the actual risk.
+- Use the `quality-release` assessment to help the developer and QA lead choose and, when useful, author a focused test-first loop for deterministic high-risk behavior.
 - Escalate when implementation reveals an invalid assumption or an expanded blast radius; re-plan before continuing.
 
 Architecture work is optional for low-risk, known-pattern changes. Deployment is always target-specific and requires explicit approval.

--- a/skills/quality-release/SKILL.md
+++ b/skills/quality-release/SKILL.md
@@ -34,6 +34,21 @@ For each meaningful change, make the following visible in the issue or pull requ
 
 Use automated tests where they protect repeatable behavior. Add focused manual checks for visual, interaction, accessibility, and environment-specific behavior that tests do not cover.
 
+## Use test-first selectively
+
+Choose a test-first loop when the expected behavior is stable enough to describe before implementation and an executable test would reduce meaningful risk. It is especially useful for business rules, data transformations, authorization, API contracts, bug regressions, state transitions, and other deterministic behavior.
+
+Do not require it for exploratory work, visual or copy changes, a still-unclear product decision, or behavior that can only be assessed credibly in the real interface or environment.
+
+When test-first is appropriate:
+
+1. Make the relevant acceptance criterion observable and agree on the intended behavior.
+2. Let the developer, QA lead, or tech lead create a focused failing test that demonstrates the intended behavior and fails for the expected reason.
+3. Implement the smallest change that makes the test pass, then refactor without changing the agreed behavior.
+4. Run the proportionate regression and manual checks that the test cannot replace.
+
+Treat a passing test as evidence, not as proof that the whole product change is ready. Keep the acceptance criteria, test evidence, and remaining limits visible in the issue or pull request.
+
 ## Release and outcome
 
 Do not treat a merge or deployment as completion. Before release, confirm the target environment, rollback path, monitoring or logs, and required approval. Do not deploy or change production systems without explicit authorization.


### PR DESCRIPTION
## Summary
- add risk-based guidance for using a test-first loop
- identify suitable deterministic behavior and cases where test-first is not appropriate
- allow developer, QA lead, or tech lead to create focused failing tests before implementation
- require regression and manual checks that tests cannot replace

Closes #11

## Validation
- YAML front matter parsed with Ruby YAML.safe_load
- git diff --check