### PR TITLE
Make GitHub Issues the default work tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A portable, risk-based workflow kit for building digital products with Claude Code, Codex, or OpenCode.
 
-V2 replaces a rigid multi-agent pipeline with one shared product context and selective specialist work. It keeps human decisions deliberate, uses GitHub for work status when GitHub is chosen, and treats launch as the start of outcome learning—not the end of the work.
+V2 replaces a rigid multi-agent pipeline with one shared product context and selective specialist work. It keeps human decisions deliberate, uses GitHub Issues as the default work record when GitHub is chosen, and treats launch as the start of outcome learning—not the end of the work.
 
 > V2 is currently introduced on `feat/v2-portable-workflow-kit`. The legacy V1 commands and hook remain in the repository only to avoid breaking existing installs; new setups should use the V2 skills and templates.
 
@@ -30,7 +30,7 @@ The Git repository is the source of the kit. Each product uses a reviewed local 
 | V1 | V2 |
 | --- | --- |
 | Fixed seven-phase pipeline | Risk triage selects only discovery, design, technical, quality, and release work that is useful. |
-| Handoff documents and `STATUS.md` | GitHub tracks work state; the repository contains only durable product, design, and decision context. |
+| Handoff documents and `STATUS.md` | GitHub Issues track work state; a Project is optional when a board or roadmap adds coordination value. The repository contains only durable product, design, and decision context. |
 | Nano Banana → v0 as the design path | Impeccable, image generation, and v0 are optional tools selected for a concrete purpose. |
 | One Claude Code setup | Portable core plus thin, project-local adapters for Claude Code, Codex, and OpenCode. |
 | Deployment as the finish line | Relevant releases include a post-launch signal and a decision to iterate, scale, stop, or investigate. |
@@ -144,7 +144,7 @@ hooks/                  V1 hook retained for existing projects only
 
 - Product outcome before process compliance.
 - One portable core; runtime-specific behavior stays in thin adapters.
-- GitHub tracks work state when selected; product files capture only durable context.
+- GitHub Issues track work state when selected; add a Project only for a requested board or a real coordination need. Product files capture only durable context.
 - Tools create evidence, never replace user decisions.
 - Risk determines depth of work and verification.
 - Deployment needs explicit authorization; a product learns after it ships.

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -8,7 +8,7 @@ The V1 `--scope nano|micro|standard|large` and `--from <phase>` flags are not su
 
 1. Add the files from `templates/product/` to the target product and fill in `PRODUCT.md`.
 2. Link or copy the selected V2 skills into the runtime's project-local skill directory.
-3. Keep GitHub Issues and the project board for status; do not create `STATUS.md` or phase handoff files.
+3. Keep GitHub Issues as the primary work record. Retain or add a GitHub Project only when a board or roadmap has a concrete coordination benefit; do not create `STATUS.md` or phase handoff files.
 4. Move only still-relevant durable rules from `docs/sot/` into `docs/decisions/`; leave historical files in place with a deprecation note.
 5. Replace a mandatory Nano Banana/v0 chain with an explicit design choice. Impeccable, image generation, and v0 are optional tools, not workflow phases.
 6. Do not install the V1 session-start hook. It depends on `STATUS.md` and is intentionally not part of V2.

--- a/skills/kickoff/SKILL.md
+++ b/skills/kickoff/SKILL.md
@@ -35,7 +35,7 @@ With approval, create the product-local context from `templates/product/`:
 
 Record the workflow kit's Git commit or release tag in `PRODUCT.md`. This pins the kickoff to the kit version actually used; it must not silently follow a newer remote revision.
 
-Use GitHub Issues and a project board for work status only when the user chooses GitHub. Requirements and acceptance criteria belong to the relevant issue, not a parallel phase handoff or `STATUS.md`.
+When GitHub is the chosen tracker, use GitHub Issues as the default work record for status, priorities, requirements, and acceptance criteria. Add a GitHub Project only when the user explicitly asks for a board or roadmap, or when the volume and coordination needs make it materially useful. Do not create a Project merely to satisfy the workflow. Do not use a parallel phase handoff or `STATUS.md`.
 
 ## 3. Triage the work
 

--- a/templates/product/AGENTS.md
+++ b/templates/product/AGENTS.md
@@ -15,7 +15,7 @@ Read the existing code and conventions before proposing an implementation.
 
 ## Source of truth
 
-- GitHub Issues and the project board track work status, priorities, and acceptance criteria.
+- GitHub Issues track work status, priorities, and acceptance criteria when GitHub is the chosen tracker. Add a GitHub Project only when the user explicitly wants a board or roadmap, or when coordination needs justify it.
 - `PRODUCT.md` captures durable product context.
 - `DESIGN.md` captures the current design direction and system decisions.
 - `docs/decisions/` records durable, consequential decisions and contracts.


### PR DESCRIPTION
## Summary

- Make GitHub Issues the default work record for status, priorities, and acceptance criteria.
- Treat GitHub Projects as optional for an explicitly requested board or a real coordination need.
- Update the kickoff skill, product template, migration guidance, and README consistently.

## Validation

- `quick_validate.py skills/kickoff`
- `git diff --check`